### PR TITLE
Allow configurable api_url for different environments

### DIFF
--- a/charts/yo-frontend/templates/deployment.yaml
+++ b/charts/yo-frontend/templates/deployment.yaml
@@ -47,5 +47,16 @@ spec:
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         resources:
 {{ toYaml .Values.resources | indent 12 }}
+        # Mount the generated config.js file for setting window.env in the
+        # application
+        volumeMounts:
+          - name: environment-volume
+            mountPath: /usr/share/nginx/html/public/config.js
+            subPath: config.jx
+      volumes:
+        - name: environment-volume
+          configMap:
+            name: environment-config
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- end }}
+

--- a/charts/yo-frontend/templates/deployment.yaml
+++ b/charts/yo-frontend/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
         # application
         volumeMounts:
           - name: environment-volume
-            mountPath: /usr/share/nginx/html/public/config.js
-            subPath: config.jx
+            mountPath: /usr/share/nginx/html/config.js
+            subPath: config.js
       volumes:
         - name: environment-volume
           configMap:

--- a/charts/yo-frontend/templates/environment-config.yaml
+++ b/charts/yo-frontend/templates/environment-config.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: environment-config
+data:
+  config.js: |
+    window.env = {}
+    window.env.API_URL='{{ .Values.env.api_url }}'

--- a/charts/yo-frontend/values.yaml
+++ b/charts/yo-frontend/values.yaml
@@ -9,6 +9,7 @@ image:
 
 # define environment variables here as a map of key: value
 env:
+  api_url: "default.api.url"
 
 # enable this flag to use knative serve to deploy the app
 knativeDeploy: false


### PR DESCRIPTION
- This lays the groundwork for being able to spin up a `yo-backend` instance and connect to it for each `yo-frontend` preview environment.

- Additionally, this will allow us to update the corresponding `staging` and `production` environment values to allow the frontend and backend to communicate there.